### PR TITLE
Rewrote CustomDiagnosticTask#getComment() to allow selfdiagnose.xml to override the task comment

### DIFF
--- a/src/main/java/com/philemonworks/selfdiagnose/CustomDiagnosticTask.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/CustomDiagnosticTask.java
@@ -71,7 +71,11 @@ public class CustomDiagnosticTask extends DiagnosticTask {
 	}	
 	
 	public String getComment() {
-	    return task == null ? super.getComment() : task.getComment();
+		String comment = super.getComment();
+		if (comment == null && task != null) {
+			comment = task.getComment();
+		}
+		return comment;
 	}
     public String getReference() {
         return reference;


### PR DESCRIPTION
Rewrote CustomDiagnosticTask#getComment() to allow selfdiagnose.xml to override the task comment, using the referred task as a fallback.

Previously, the referred task was the primary comment source. This resulted in the use of multiple locations for the values in the 'left column' of the selfdiagnose page.
