### PR TITLE
Add option to set timeout on selfdiagnose

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+### 2.8.8
+- Added timeout option to selfdiagnose call
 ### 2.8.7
 - changed msg of environment property checker
 ### 2.8.6

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.philemonworks</groupId>
     <artifactId>selfdiagnose</artifactId>
     <packaging>jar</packaging>
-    <version>2.8.7</version>
+    <version>2.8.8</version>
     <name>SelfDiagnose</name>
     <url>http://github.com/emicklei/selfdiagnose</url>
     <description>SelfDiagnose - library of tasks to verify an execution environment at runtime</description>

--- a/src/main/java/com/philemonworks/selfdiagnose/SelfDiagnose.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/SelfDiagnose.java
@@ -53,7 +53,7 @@ public abstract class SelfDiagnose {
     /**
      * The name of the resource that holds the specification of tasks.
      */
-    public final static String VERSION = "2.8.7";
+    public final static String VERSION = "2.8.8";
     public final static String COPYRIGHT = "(c) ernestmicklei.com";
     public final static String CONFIG = "selfdiagnose.xml";
     private static URL CONFIG_URL = null; // will be initialized by configure(...)
@@ -199,6 +199,13 @@ public abstract class SelfDiagnose {
     /**
      * Basic method to run all registered tasks.
      */
+    public static DiagnoseRun runTasks(DiagnoseRunReporter reporter, Integer timeout) {
+        return SelfDiagnose.runTasks(tasks, reporter, new ExecutionContext(), timeout);
+    }
+
+    /**
+     * Basic method to run all registered tasks.
+     */
     public static DiagnoseRun runTasks(DiagnoseRunReporter reporter, ExecutionContext ctx) {
         return SelfDiagnose.runTasks(tasks, reporter, ctx, null);
     }
@@ -243,7 +250,7 @@ public abstract class SelfDiagnose {
     private static List<DiagnosticTaskResult> createErrorResult(String message) {
         List<DiagnosticTaskResult> result = new ArrayList<DiagnosticTaskResult>(1);
         final ReportStaticMessageTask task = new ReportStaticMessageTask(false, message, "System Error Message");
-        
+
         result.add(task.run());
         return result;
     }
@@ -295,7 +302,7 @@ public abstract class SelfDiagnose {
                     // Probably because future is cancelled. Don't continue scheduling/executing new tasks
                     return results;
                 }
-                
+
                 DiagnosticTask each = (DiagnosticTask) taskList.get(i);
                 DiagnosticTaskResult result = null;
                 // see if task wants to run with a timeout

--- a/src/main/java/com/philemonworks/selfdiagnose/check/ReportStaticMessageTask.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/check/ReportStaticMessageTask.java
@@ -1,0 +1,44 @@
+package com.philemonworks.selfdiagnose.check;
+
+import com.philemonworks.selfdiagnose.DiagnoseException;
+import com.philemonworks.selfdiagnose.DiagnosticTask;
+import com.philemonworks.selfdiagnose.DiagnosticTaskResult;
+import com.philemonworks.selfdiagnose.ExecutionContext;
+
+/**
+ * Class to report a message with a given status.
+ * <p>
+ * This task doesn't actually check anything, it just adds a line to the report.
+ */
+public class ReportStaticMessageTask extends DiagnosticTask {
+
+    private final boolean passed;
+    private final String message;
+    private final String description;
+
+    /**
+     * @param passed  true and this check is considered to be passed, otherwise failed.
+     * @param message The message to display
+     */
+    public ReportStaticMessageTask(boolean passed, String message, String description) {
+        super();
+
+        this.passed = passed;
+        this.message = message;
+        this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void run(ExecutionContext ctx, DiagnosticTaskResult result) throws DiagnoseException {
+        if (passed) {
+            result.setPassedMessage(message);
+        } else {
+            result.setFailedMessage(message);
+        }
+    }
+}

--- a/src/main/java/com/philemonworks/selfdiagnose/check/vendor/SelfDiagnoseResource.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/check/vendor/SelfDiagnoseResource.java
@@ -36,7 +36,7 @@ public class SelfDiagnoseResource implements ApplicationContextAware {
     @GET
     @Produces("text/html,application/xml,application/json")
     @Consumes("text/html,application/xml")
-    public Response runAndReportResults(@PathParam("extension") String format, @QueryParam("format") String formatOverride) {
+    public Response runAndReportResults(@PathParam("extension") String format, @QueryParam("format") String formatOverride, @QueryParam("timeoutMS") Integer timeout) {
         DiagnoseRunReporter reporter;
         ResponseBuilder builder = Response.ok();
         if (".xml".equals(format) || "xml".equals(formatOverride)) {
@@ -49,7 +49,7 @@ public class SelfDiagnoseResource implements ApplicationContextAware {
             reporter = new HTMLReporter();
             builder.header("Content-Type", "text/html");
         }
-        DiagnoseRun run = SelfDiagnose.runTasks(reporter);
+        DiagnoseRun run = SelfDiagnose.runTasks(reporter, timeout);
         builder.header("X-SelfDiagnose-OK", run.isOK());
         return builder.entity(reporter.getContent()).build();
     }
@@ -67,7 +67,7 @@ public class SelfDiagnoseResource implements ApplicationContextAware {
         } catch (Exception e) {
             return Response.serverError().entity(e.getCause().getMessage()).build();
         }
-        return this.runAndReportResults(format, null);
+        return this.runAndReportResults(format, null, null);
     }
 
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {

--- a/src/test/java/com/philemonworks/selfdiagnose/test/SelfDiagnoseServletTest.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/SelfDiagnoseServletTest.java
@@ -69,5 +69,5 @@ public class SelfDiagnoseServletTest extends TestCase {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-    }    
+    }
 }

--- a/src/test/java/com/philemonworks/selfdiagnose/test/SelfDiagnoseTest.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/SelfDiagnoseTest.java
@@ -1,28 +1,66 @@
 package com.philemonworks.selfdiagnose.test;
 
+import com.philemonworks.selfdiagnose.*;
+import com.philemonworks.selfdiagnose.output.DiagnoseRunReporter;
+import com.philemonworks.selfdiagnose.output.HTMLReporter;
+import junit.framework.TestCase;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import junit.framework.TestCase;
-
-import com.philemonworks.selfdiagnose.SelfDiagnose;
-
 public class SelfDiagnoseTest extends TestCase {
-    public void testConfigure(){
-        SelfDiagnose.configure((URL)null);
+    public void testConfigure() {
+        SelfDiagnose.configure((URL) null);
     }
-    public void testReload(){
+
+    public void testReload() {
         SelfDiagnose.reloadConfiguration();
     }
-    public void testRun(){
+
+    public void testRun() {
         SelfDiagnose.runTasks();
     }
-    public void testConfigureReal(){
+
+    public void testConfigureReal() {
         SelfDiagnose.configure("selfdiagnose-test.xml");
-        assertEquals("tasks from test.xml",21,SelfDiagnose.getTasks().size());
+        assertEquals("tasks from test.xml", 21, SelfDiagnose.getTasks().size());
     }
-    public void testConfigureURLReal() throws MalformedURLException{
+
+    public void testConfigureURLReal() throws MalformedURLException {
         SelfDiagnose.configure(new URL("file:///src/test/resources/selfdiagnose-test.xml"));
-        assertEquals("tasks from test.xml",0,SelfDiagnose.getTasks().size());
-    }    
+        assertEquals("tasks from test.xml", 0, SelfDiagnose.getTasks().size());
+    }
+
+    public void testWithTimeout_NoTimeout() {
+        SelfDiagnose.configure("selfdiagnose-ok.xml");
+        DiagnoseRunReporter reporter = new HTMLReporter();
+        ExecutionContext ctx = new ExecutionContext();
+        SelfDiagnose.runTasks(reporter, ctx, 100);
+        assertTrue(reporter.getContent().contains("Failures: 0"));
+    }
+
+    public void testWithTimeout_Timeout() {
+        SelfDiagnose.configure("selfdiagnose-ok.xml");
+        SelfDiagnose.getTasks().add(new DiagnosticTask() {
+            @Override
+            public String getDescription() {
+                return "takes a long time";
+            }
+
+            @Override
+            public void run(ExecutionContext ctx, DiagnosticTaskResult result) throws DiagnoseException {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    fail("Should not be interrupted");
+                }
+            }
+        });
+        DiagnoseRunReporter reporter = new HTMLReporter();
+        ExecutionContext ctx = new ExecutionContext();
+        SelfDiagnose.runTasks(reporter, ctx, 1);
+        assertTrue(reporter.getContent().contains("Failures: 1"));
+        assertTrue(reporter.getContent().contains("Could not execute all SelfDiagnose tasks within specified limit of 1 ms."));
+    }
+
 }

--- a/src/test/resources/selfdiagnose-ok.xml
+++ b/src/test/resources/selfdiagnose-ok.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<!-- DOCTYPE selfdiagnose PUBLIC
+    "-//SelfDiagnose/SelfDiagnose Configuration DTD 1.0//EN"
+    "http://www.philemonworks.com/dtd/selfdiagnose-1.0.dtd" -->
+<!-- declaration is commented for sake of local testing -->
+
+<!-- Some checks which run ok-->
+<selfdiagnose>
+    <tasks>
+        <checkresourceaccessible name="log4j.properties"/>
+        <checkclassloadable name="org.apache.log4j.Logger"/>
+    </tasks>
+</selfdiagnose>


### PR DESCRIPTION
The resource and servlet now support an optional timeoutMS parameter, which, if set, limits the total time of all checks together to the given timeout. If the timeout is exceeded a result containing a single error check is generated.