### PR TITLE
Fix classloading issues for WAR files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.philemonworks</groupId>
     <artifactId>selfdiagnose</artifactId>
     <packaging>jar</packaging>
-    <version>2.9.0</version>
+    <version>2.9.1</version>
     <name>SelfDiagnose</name>
     <url>http://github.com/emicklei/selfdiagnose</url>
     <description>SelfDiagnose - library of tasks to verify an execution environment at runtime</description>

--- a/src/main/java/com/philemonworks/selfdiagnose/ExecutionContext.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/ExecutionContext.java
@@ -29,9 +29,8 @@ public class ExecutionContext {
      *
      * @param variableName : String || null
      * @param newValue     : Object
-     * @throws DiagnoseException
      */
-    public void setValue(String variableName, Object newValue) throws DiagnoseException {
+    public void setValue(String variableName, Object newValue) {
         // only store the value if a variable name was specified
         if (variableName != null)
             values.put(variableName, newValue);


### PR DESCRIPTION
SelfDiagnoseResource now sets the ServletContext to the ExecutionContext in order to fix classloading issues in ReportMavenPOMProperties if a WAR is used. 

Also removed checked exception from ExecutionContext.setValue since it is never thrown.