### PR TITLE
Prevent `java.lang.OutOfMemoryError: unable to create new native thre…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+### 2.10.0
+- Prevent `java.lang.OutOfMemoryError: unable to create new native thread` that might happen if diagnostic tasks do not complete within a timeout period
 ### 2.9.0
 - adds "checks" and "failures" attributes to JSON and XML reporter, just like HTML
 ### 2.8.8

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.philemonworks</groupId>
     <artifactId>selfdiagnose</artifactId>
     <packaging>jar</packaging>
-    <version>2.9.2</version>
+    <version>2.10.0-SNAPSHOT</version>
     <name>SelfDiagnose</name>
     <url>http://github.com/emicklei/selfdiagnose</url>
     <description>SelfDiagnose - library of tasks to verify an execution environment at runtime</description>

--- a/src/main/java/com/philemonworks/selfdiagnose/SelfDiagnose.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/SelfDiagnose.java
@@ -59,6 +59,8 @@ public abstract class SelfDiagnose {
 
     private static List<DiagnosticTask> tasks = Collections.synchronizedList(new ArrayList<DiagnosticTask>());
 
+    private static final TaskBackgroundRunner BACKGROUND_RUNNER = new TaskBackgroundRunner(100);
+
     static {
         SelfDiagnose.configure(CONFIG);
     }
@@ -202,7 +204,7 @@ public abstract class SelfDiagnose {
             DiagnosticTaskResult result = null;
             // see if task wants to run with a timeout
             if (each.needsLimitedRuntime()) {
-                result = new TaskBackgroundRunner().runWithin(each, ctx, each.getTimeoutInMilliSeconds());
+                result = BACKGROUND_RUNNER.runWithin(each, ctx, each.getTimeoutInMilliSeconds());
             } else {
                 result = each.run(ctx);
             }

--- a/src/main/java/com/philemonworks/selfdiagnose/TaskBackgroundRunner.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/TaskBackgroundRunner.java
@@ -1,10 +1,14 @@
 package com.philemonworks.selfdiagnose;
 
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.log4j.Logger;
 
@@ -13,58 +17,84 @@ import org.apache.log4j.Logger;
  * If the task does not complete in time, it will report an error. The task is not aborted so may complete afterwards.
  * 
  * @author emicklei
- *
+ * @author Yaroslav Skopets
  */
 public class TaskBackgroundRunner {
     private static final Logger log = Logger.getLogger(SelfDiagnose.class);
-    
-    // threads are removed from the pool if no longer used.
-    static final ExecutorService SharedPool = Executors.newCachedThreadPool(new ThreadFactory() {
-        public Thread newThread(Runnable r) {
-            Thread runner = new Thread(r);
-            runner.setDaemon(true);
-            runner.setName("SelfDiagnose.TaskBackgroundRunner");
-            return runner;
-        }
-    });
 
-    DiagnosticTaskResult result;
+    private static ExecutorService newCachedThreadPool(int maximumPoolSize) {
+        return new ThreadPoolExecutor(0, maximumPoolSize,
+                // threads are removed from the pool if no longer used.
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(),
+                new ThreadFactory() {
+                    public Thread newThread(Runnable r) {
+                        final Thread runner = new Thread(r);
+                        runner.setDaemon(true);
+                        runner.setName("SelfDiagnose.TaskBackgroundRunner");
+                        return runner;
+                    }
+                });
+    }
+
+    private final ExecutorService executor;
+
+    public TaskBackgroundRunner(int maximumPoolSize) {
+        this(newCachedThreadPool(maximumPoolSize));
+    }
+
+    public TaskBackgroundRunner(ExecutorService executor) {
+        this.executor = executor;
+    }
 
     /**
      * Run the task but do not wait for it to complete after the specified number of milliseconds.
      */
     public DiagnosticTaskResult runWithin(final DiagnosticTask task, final ExecutionContext ctx, final int timeoutInMilliseconds) {
-        final CountDownLatch latch = new CountDownLatch(1);
-        SharedPool.execute(new Runnable() {
-            public void run() {
-                DiagnosticTaskResult actualResult = task.run(ctx);
-                // do not overwrite a timeout result
-                if (TaskBackgroundRunner.this.result == null) {
-                    TaskBackgroundRunner.this.result = actualResult;
-                } else {
-                    // the result came too late, log that as a warning
-                    log.warn("task " + task.getTaskName() + " completed in " + actualResult.getExecutionTime() + " [ms] which is longer than timeout of " + timeoutInMilliseconds + " [ms]");
-                }
-                latch.countDown();
-            }
-        });
         try {
-            boolean inTime = latch.await(timeoutInMilliseconds, TimeUnit.MILLISECONDS);
-            if (!inTime) {
+            final Future<DiagnosticTaskResult> future = executor.submit(new Callable<DiagnosticTaskResult>() {
+                @Override
+                public DiagnosticTaskResult call() throws Exception {
+                    return task.run(ctx);
+                }
+            });
+            return waitForCompletion(task, timeoutInMilliseconds, future);
+        } catch (RejectedExecutionException e) {
+            return handleFailure(e, "task cannot be scheduled for execution (no more threads left in the pool)", task, timeoutInMilliseconds);
+        }
+    }
+
+    protected DiagnosticTaskResult waitForCompletion(final DiagnosticTask task, final int timeoutInMilliseconds, final Future<DiagnosticTaskResult> future) {
+        try {
+            DiagnosticTaskResult result = future.get(timeoutInMilliseconds, TimeUnit.MILLISECONDS);
+            // if result was not set for some reason then create it with a failure
+            if (result == null) {
                 result = task.createResult();
-                result.setFailedMessage("task execution timed out after " + timeoutInMilliseconds + " milliseconds");
-                result.setExecutionTime(timeoutInMilliseconds);
+                result.setFailedMessage("unexpected empty result in background runner");
             }
+            return result;
         } catch (InterruptedException e) {
-            result = task.createResult();
-            result.setFailedMessage("interrupted execution");
-            result.setExecutionTime(timeoutInMilliseconds); // could be less
+            Thread.currentThread().interrupt();
+
+            return handleFailure(e, "task execution was interrupted", task, timeoutInMilliseconds);
+        } catch (TimeoutException e) {
+            return handleFailure(e, "task execution timed out after " + timeoutInMilliseconds + " milliseconds", task, timeoutInMilliseconds);
+        } catch (Exception e) {
+            return handleFailure(e, "task execution failed", task, timeoutInMilliseconds);
+        } finally {
+            if (!future.isDone()) {
+                // cancel the future to release a thread back to the pool
+                future.cancel(true);
+            }
         }
-        // if result was not set for some reason then create it with a failure
-        if (result == null) {
-            result = task.createResult();
-            result.setFailedMessage("unexpected empty result in background runner");
-        }
+    }
+
+    protected DiagnosticTaskResult handleFailure(Exception e, String message, DiagnosticTask task, int timeoutInMilliseconds) {
+        log.error(message, e);
+
+        final DiagnosticTaskResult result = task.createResult();
+        result.setFailedMessage(message);
+        result.setExecutionTime(timeoutInMilliseconds); // could be less
         return result;
     }
 }

--- a/src/test/java/com/philemonworks/selfdiagnose/test/SleepTask.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/SleepTask.java
@@ -1,0 +1,39 @@
+package com.philemonworks.selfdiagnose.test;
+
+import com.philemonworks.selfdiagnose.DiagnoseException;
+import com.philemonworks.selfdiagnose.DiagnosticTask;
+import com.philemonworks.selfdiagnose.DiagnosticTaskResult;
+import com.philemonworks.selfdiagnose.ExecutionContext;
+
+/**
+ * Sample task that simulates a long-running activity.
+ *
+ * @author Ernest Micklei
+ * @author Yaroslav Skopets
+ */
+public class SleepTask extends DiagnosticTask {
+
+    private static final long serialVersionUID = -5193920249800557424L;
+
+    private final long interval;
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    public SleepTask(long interval) {
+        this.interval = interval;
+    }
+
+    @Override
+    public void run(ExecutionContext ctx, DiagnosticTaskResult result) throws DiagnoseException {
+        try {
+            System.out.println(String.format("[SleepTask] going to sleep for %s ms", interval));
+            Thread.sleep(interval);
+            System.out.println(String.format("[SleepTask] awake after %s ms", interval));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/philemonworks/selfdiagnose/test/SuccessfulTask.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/SuccessfulTask.java
@@ -1,0 +1,32 @@
+package com.philemonworks.selfdiagnose.test;
+
+import com.philemonworks.selfdiagnose.DiagnoseException;
+import com.philemonworks.selfdiagnose.DiagnosticTask;
+import com.philemonworks.selfdiagnose.DiagnosticTaskResult;
+import com.philemonworks.selfdiagnose.ExecutionContext;
+
+/**
+ * Sample task that simulates a successful outcome.
+ *
+ * @author Yaroslav Skopets
+ */
+public class SuccessfulTask extends DiagnosticTask {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String passedMessage;
+
+    public SuccessfulTask(String passedMessage) {
+        this.passedMessage = passedMessage;
+    }
+
+    @Override
+    public String getDescription() {
+        return "successful task";
+    }
+
+    @Override
+    public void run(ExecutionContext ctx, DiagnosticTaskResult result) throws DiagnoseException {
+        result.setPassedMessage(passedMessage);
+    }
+}

--- a/src/test/java/com/philemonworks/selfdiagnose/test/TaskBackgroundRunnerTest.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/TaskBackgroundRunnerTest.java
@@ -1,0 +1,109 @@
+package com.philemonworks.selfdiagnose.test;
+
+import com.philemonworks.selfdiagnose.DiagnosticTaskResult;
+import com.philemonworks.selfdiagnose.ExecutionContext;
+import com.philemonworks.selfdiagnose.TaskBackgroundRunner;
+import junit.framework.TestCase;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Suite of unit tests for {@link TaskBackgroundRunner}.
+ *
+ * @author Yaroslav Skopets
+ */
+public class TaskBackgroundRunnerTest extends TestCase {
+
+    private final ExecutionContext context = new ExecutionContext();
+
+    private ExecutorService executor;
+
+    @Override
+    protected void setUp() throws Exception {
+        // `ExecutorService` that is very close to the one that will be used in production
+        executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        executor.shutdown();
+    }
+
+    public void testTaskThatDoesNotCompleteWithinTimeoutShouldFail() {
+        // setup
+        final TaskBackgroundRunner runner = new TaskBackgroundRunner(executor);
+
+        // given
+        final SleepTask slowTask = new SleepTask(100 * 10);
+        slowTask.setTimeoutInMilliSeconds(100);
+
+        // when
+        final DiagnosticTaskResult slowTaskRun = runner.runWithin(slowTask, context, slowTask.getTimeoutInMilliSeconds());
+
+        // then
+        assertTrue(slowTaskRun.isFailed());
+    }
+
+    public void testTaskThatDoesNotCompleteWithinTimeoutShouldReleaseThread() throws InterruptedException {
+        // setup
+        final TaskBackgroundRunner runner = new TaskBackgroundRunner(executor);
+
+        // given
+        final SleepTask slowTask = new SleepTask(100 * 10);
+        slowTask.setTimeoutInMilliSeconds(100);
+
+        // when
+        final DiagnosticTaskResult slowTaskRun = runner.runWithin(slowTask, context, slowTask.getTimeoutInMilliSeconds());
+
+        // then
+        assertTrue(slowTaskRun.isFailed());
+
+        // given
+        final SuccessfulTask normalTask = new SuccessfulTask("passing check");
+        normalTask.setTimeoutInMilliSeconds(100);
+
+        // when
+
+        // give JVM a few cycles to switch threads and interrupt cancelled task
+        Thread.sleep(10);
+        // schedule the next task
+        final DiagnosticTaskResult normalTaskRun = runner.runWithin(normalTask, context, normalTask.getTimeoutInMilliSeconds());
+
+        // then
+        assertTrue(normalTaskRun.isPassed());
+    }
+
+    public void testTaskShouldFailIfThereAreNoMoreThreadsLeftInThePool() throws InterruptedException {
+        // setup
+        final TaskBackgroundRunner runner = new TaskBackgroundRunner(executor);
+
+        // given
+        final SleepTask slowTask = new SleepTask(100 * 10);
+        slowTask.setTimeoutInMilliSeconds(100);
+
+        // when
+
+        // all threads in the pool are blocked by long-running tasks
+        Executors.newSingleThreadExecutor().submit(new Runnable() {
+            @Override
+            public void run() {
+                runner.runWithin(slowTask, context, slowTask.getTimeoutInMilliSeconds());
+            }
+        });
+        // give JVM a few cycles to switch threads and start the task
+        Thread.sleep(10);
+
+        // given
+        final SuccessfulTask normalTask = new SuccessfulTask("passing check");
+        normalTask.setTimeoutInMilliSeconds(100);
+
+        final DiagnosticTaskResult normalTaskRun = runner.runWithin(normalTask, context, normalTask.getTimeoutInMilliSeconds());
+
+        // then
+        assertTrue(normalTaskRun.isFailed()); // no more free threads in the pool
+    }
+}

--- a/src/test/java/com/philemonworks/selfdiagnose/test/TasksTest.java
+++ b/src/test/java/com/philemonworks/selfdiagnose/test/TasksTest.java
@@ -47,7 +47,7 @@ public class TasksTest extends TestCase {
     }
 
     public void testTimeoutTask() {
-        SleepTask sleep = new SleepTask();
+        SleepTask sleep = new SleepTask(100 * 2);
         sleep.setTimeoutInMilliSeconds(100);
 
         DiagnoseRun run = runSingleTask(sleep);
@@ -57,7 +57,7 @@ public class TasksTest extends TestCase {
     }
 
     public void testTimeoutCustomTask() {
-        SleepTask sleep = new SleepTask();
+        SleepTask sleep = new SleepTask(100 * 2);
         CustomDiagnosticTask ct = new CustomDiagnosticTask();
         // set task before attributes
         ct.setTask(sleep);
@@ -96,26 +96,6 @@ public class TasksTest extends TestCase {
         SelfDiagnose.flush();
         SelfDiagnose.register(task);
         return SelfDiagnose.runTasks(new XMLReporter());
-    }
-
-    static class SleepTask extends DiagnosticTask {
-        private static final long serialVersionUID = -5193920249800557424L;
-
-        @Override
-        public String getDescription() {
-            return null;
-        }
-
-        @Override
-        public void run(ExecutionContext ctx, DiagnosticTaskResult result) throws DiagnoseException {
-            try {
-                System.out.println("[SleepTask] going to sleep for 200ms");
-                Thread.sleep(100 * 2);
-                System.out.println("[SleepTask] awake after 200ms");
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
     }
 
     static class CustomSeverityTask extends DiagnosticTask {


### PR DESCRIPTION
Prevent `java.lang.OutOfMemoryError: unable to create new native thread` that might happen if diagnostic tasks do not complete within a timeout period