### PR TITLE
Only overwrite task config if values explicitly specified or non-default

### DIFF
--- a/src/main/java/com/philemonworks/selfdiagnose/CustomDiagnosticTask.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/CustomDiagnosticTask.java
@@ -73,10 +73,21 @@ public class CustomDiagnosticTask extends DiagnosticTask {
     public void setTask(DiagnosticTask task) {
         if (task == null) return;
         // copy attributes set by config
-        task.setComment(this.getComment());
-        task.setSeverity(this.getSeverity());
-        task.setTimeoutInMilliSeconds(this.getTimeoutInMilliSeconds());
-        task.setVariableName(this.getVariableName());
+
+        String comment = this.getComment();
+        if (!(comment == null || comment.isEmpty())) {
+            task.setComment(this.getComment());
+        }
+        if (!this.isDefaultSeverity()) {
+            task.setSeverity(this.getSeverity());
+        }
+        if (this.getTimeoutInMilliSeconds() > 0) {
+            task.setTimeoutInMilliSeconds(this.getTimeoutInMilliSeconds());
+        }
+        String variableName = this.getVariableName();
+        if (!(variableName == null || variableName.isEmpty())) {
+            task.setVariableName(this.getVariableName());
+        }
         this.task = task;
     }
 

--- a/src/main/java/com/philemonworks/selfdiagnose/DiagnosticTask.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/DiagnosticTask.java
@@ -80,6 +80,10 @@ public abstract class DiagnosticTask implements Serializable {
      * By default, severity is set to critical.
      */
     private Severity severity = Severity.CRITICAL;
+    /**
+     * Used to detect if the severity has been explicitly specified.
+     */
+    private boolean defaultSeverity = true;
 
     /**
      * Return an object to store the results of running the receiver.
@@ -285,6 +289,10 @@ public abstract class DiagnosticTask implements Serializable {
         return severity;
     }
 
+    public boolean isDefaultSeverity() {
+        return defaultSeverity;
+    }
+
     /**
      * Make sure that severity is set correctly within the allowed values, see {@link Severity} enumeration.
      * @param severity
@@ -294,6 +302,7 @@ public abstract class DiagnosticTask implements Serializable {
             throw new NullPointerException("severity == NULL");
         }
         this.severity = severity;
+        this.defaultSeverity = false;
     }
 
 }


### PR DESCRIPTION
The recent change in commit 5baf4e55f9b043a2174fbccc69b4935e7daf3872 was causing custom tasks that had been initialized in code with severity WARNING to be severity CRITICAL instead, also description specified in code was overwritten as empty / null.