### PR TITLE
Shading OGNL and Javasist into Selfdiagnose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea/*
 .svn/*
 target/*
+dependency-reduced-pom.xml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+### 2.11.0
+- OGNL and Javassist are now shaded into selfdiagnose. This solves dependency conflict issues.
 ### 2.10.1
 - Read version from pom.properties
 - fix problem with override task config

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.philemonworks</groupId>
     <artifactId>selfdiagnose</artifactId>
     <packaging>jar</packaging>
-    <version>2.10.1</version>
+    <version>2.11.0-SNAPSHOT</version>
     <name>SelfDiagnose</name>
     <url>http://github.com/emicklei/selfdiagnose</url>
     <description>SelfDiagnose - library of tasks to verify an execution environment at runtime</description>
@@ -144,6 +144,37 @@
                 <version>3.4</version>
                 <configuration>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>ognl:ognl</include>
+                                    <include>javassist:javassist</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>ognl</pattern>
+                                    <shadedPattern>com.philemonworks.selfdiagnose._shaded.ognl</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javassist</pattern>
+                                    <shadedPattern>com.philemonworks.selfdiagnose._shaded.javassist</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I would like to shade OGNL and Javassist into Selfdiagnose. This is mainly because of Javassist. The version that is used within OGNL is so old that it now causes issues when combined with libraries like Hibernate.

Because OGNL is only used internally within Selfdiagnose, it is fairly easy to just shade it into the artifact. I tested this locally and it works great.